### PR TITLE
Replace "_nodeType" with "nodeType.name" in the root matcher

### DIFF
--- a/Packages/Sites/Flowpack.FusionBP/Resources/Private/Fusion/Root.fusion
+++ b/Packages/Sites/Flowpack.FusionBP/Resources/Private/Fusion/Root.fusion
@@ -3,7 +3,8 @@ include: Override.fusion
 
 root {
     default {
-        type = ${q(node).property('_nodeType') + '.Document'}
+        // Override the default root matcher to render document nodes with a prototype of the same name + ".Document" suffix
+        type = ${node.nodeType.name + '.Document'}
         renderPath >
     }
 }


### PR DESCRIPTION
The part `${q(node).property('_nodeType')` is a little bit of a hack IMO. So this patch
suggests to change that to ``${node.nodeType.name}``.
I also added an inline comment describing what's happening